### PR TITLE
Add manual trigger to firebase-distribute.yml and fix Firebase auth

### DIFF
--- a/.github/workflows/firebase-distribute.yml
+++ b/.github/workflows/firebase-distribute.yml
@@ -83,19 +83,24 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.1"
+          bundler-cache: true
 
-      - name: 🧪 Install Fastlane + Firebase plugin
-        run: |
-          cd android
-          gem install fastlane
-          fastlane add_plugin firebase_app_distribution
+      - name: 🧪 Install Fastlane dependencies
+        working-directory: android
+        run: bundle install
 
       - name: 🚀 Build and Upload APK to Firebase
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
         run: |
           cd android
-          fastlane beta
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > "$RUNNER_TEMP/firebase-service-account.json"
+            export FIREBASE_SERVICE_ACCOUNT_FILE="$RUNNER_TEMP/firebase-service-account.json"
+          fi
+
+          bundle exec fastlane beta
 
       - name: 📤 Upload APK to GitHub Releases
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/firebase-distribute.yml
+++ b/.github/workflows/firebase-distribute.yml
@@ -6,6 +6,7 @@ on:
       - main
     tags:
       - "v*.*.*" # trigger release only for version tags
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/.github/workflows/flutter-tests.yml
+++ b/.github/workflows/flutter-tests.yml
@@ -3,7 +3,6 @@ name: Flutter Tests
 on:
   push:
   pull_request:
-  workflow_dispatch:
 
 permissions:
   contents: write

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -23,9 +23,9 @@ platform :android do
 
   desc "Build and distribute APK to Firebase App Distribution"
   lane :beta do
-    # Step 1: Build the APK using Flutter
-    sh("flutter clean")
-    sh("flutter build apk --release")
+    # Step 1: Build the APK using Flutter from the repository root
+    sh("cd .. && flutter clean")
+    sh("cd .. && flutter build apk --release")
 
     distribution_options = {
       app: "1:727081287744:android:ae16828e55f1b97d311fa5",

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -26,14 +26,25 @@ platform :android do
     # Step 1: Build the APK using Flutter
     sh("flutter clean")
     sh("flutter build apk --release")
-  
-    # Step 2: Upload to Firebase App Distribution
-    firebase_app_distribution(
-      app: "1:727081287744:android:ae16828e55f1b97d311fa5", 
-      groups: "internal-testers", 
+
+    distribution_options = {
+      app: "1:727081287744:android:ae16828e55f1b97d311fa5",
+      groups: "internal-testers",
       release_notes: "New test build 🚀",
       apk_path: "../build/app/outputs/flutter-apk/app-release.apk"
-    )
+    }
+
+    service_credentials_file = ENV["FIREBASE_SERVICE_ACCOUNT_FILE"]
+    firebase_cli_token = ENV["FIREBASE_TOKEN"]
+
+    if service_credentials_file && !service_credentials_file.empty?
+      distribution_options[:service_credentials_file] = service_credentials_file
+    elsif firebase_cli_token && !firebase_cli_token.empty?
+      distribution_options[:firebase_cli_token] = firebase_cli_token
+    end
+
+    # Step 2: Upload to Firebase App Distribution
+    firebase_app_distribution(distribution_options)
   end
   
 

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -41,6 +41,8 @@ platform :android do
       distribution_options[:service_credentials_file] = service_credentials_file
     elsif firebase_cli_token && !firebase_cli_token.empty?
       distribution_options[:firebase_cli_token] = firebase_cli_token
+    else
+      UI.user_error!("Missing Firebase authentication. Set FIREBASE_SERVICE_ACCOUNT_FILE or FIREBASE_TOKEN before running the beta lane.")
     end
 
     # Step 2: Upload to Firebase App Distribution

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -133,3 +133,4 @@ global_options:
 
 dependency_overrides:
   analyzer: ^6.2.0
+  dart_style: ">=2.3.6 <3.0.0"


### PR DESCRIPTION
This pull request improves the Firebase App Distribution workflow for Android releases and introduces some dependency and workflow configuration updates. The main focus is on making the Firebase upload process more flexible and secure by supporting both service account credentials and CLI tokens, and on optimizing dependency management.

**Firebase Distribution Workflow Improvements:**

* [`.github/workflows/firebase-distribute.yml`](diffhunk://#diff-663d96e99d2ca553c86c658ee0f7147a4ae7a7ab89fc4242f2b63e053f795701R9): The workflow now supports manual triggering via `workflow_dispatch`, and uses Bundler to manage Ruby dependencies, ensuring consistent Fastlane and plugin versions. It also adds support for uploading the service account JSON as a secret and passes it to Fastlane if present. [[1]](diffhunk://#diff-663d96e99d2ca553c86c658ee0f7147a4ae7a7ab89fc4242f2b63e053f795701R9) [[2]](diffhunk://#diff-663d96e99d2ca553c86c658ee0f7147a4ae7a7ab89fc4242f2b63e053f795701R86-R103)

* [`android/fastlane/Fastfile`](diffhunk://#diff-d0c99c3583617d28a3669e90c98158993dfbd7a57c6e010b1a70e2a8acaed5a6L30-R47): The `beta` lane is updated to accept either a service account file or a CLI token for Firebase authentication, improving deployment flexibility and security. The upload step now dynamically selects the appropriate authentication method based on available environment variables.

**Dependency Management:**

* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25R136): Adds a dependency override for `dart_style` to ensure compatibility with the current toolchain.

**Workflow Configuration Updates:**

* [`.github/workflows/flutter-tests.yml`](diffhunk://#diff-e806a25f6e9e9a1a7da9cf90727546bb25c62d510d309afb68ff35e6ad26d88bL6): Removes the manual workflow dispatch trigger, streamlining the workflow to only run on pushes and pull requests.